### PR TITLE
Fix base58check_encode function by using intval() function to convert…

### DIFF
--- a/src/CryptoCoin/CoinAddress.php
+++ b/src/CryptoCoin/CoinAddress.php
@@ -399,10 +399,10 @@ class CoinAddress
 
     public static function base58check_encode($leadingByte, $bin, $trailingByte = null)
     {
-        $bin = chr($leadingByte) . $bin;
+        $bin = chr(intval($leadingByte)) . $bin;
         if ($trailingByte !== null)
         {
-            $bin .= chr($trailingByte);
+            $bin .= chr(intval($trailingByte));
         }
         $checkSum = substr(hash('sha256', hash('sha256', $bin, true), true), 0, 4);
         $bin .= $checkSum;


### PR DESCRIPTION
… argument to integer (if it is string).

Otherwise notice occurs:
A non well formed numeric value encountered